### PR TITLE
Fix Agri build with new makefile system

### DIFF
--- a/mk/system/agri.make
+++ b/mk/system/agri.make
@@ -11,7 +11,7 @@ F90=               gfortran
 MPICXX=            mpiCC
 MPIF90=            mpif90
 
-CXXFLAGS+=         -fPIC
+CXXFLAGS+=         -fPIC -Wno-literal-suffix
 F90FLAGS+=         -fPIC
 
 F90_RUNTIME=       -lgfortran
@@ -32,7 +32,7 @@ PETSC_LDFLAGS=     -L$(PETSC_ROOT)/lib -L$(X11_ROOT)/lib
 # LAPACK (Mac OS X Accelerate Framework)
 LAPACK_INTERFACE=  FORTRAN
 LAPACK_CXXFLAGS=
-LAPACK_LIBRARIES=  
-LAPACK_LDFLAGS=    -llapack -lblas
+LAPACK_LIBRARIES=  -llapack -lblas
+LAPACK_LDFLAGS=    
 
 # DO NOT DELETE


### PR DESCRIPTION
LAPACK libraries should be added to the LIBRARIES variable, not LDFLAGS
Add -Wno-literal-suffix to silence a macro problem in OpenMPI headers.
